### PR TITLE
Improve Update Container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6]
+
+### Added
+
+    - Add setting parameter allowing to automatically close the terminal Window when the Container Update is successful.
+    - Add setting parameter to set the max number of allowed Container Update retries.
+
+### Fixed
+
+    - Infinite loops when the Container Update fails.
+
 ## [0.1.5]
 
 ### Added
@@ -41,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     - Add icons to side bar root items.
     - Add auto run of docker containers.
- 
+
 ## [0.1.0]
 
 ### Changed
@@ -50,7 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-    - New tasks : 
+    - New tasks :
       - Run app in Speculos,
       - Kill Speculos,
       - On device functional tests,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Provide a quick and easy way to build and test applications for [Ledger](https://www.ledger.com/) devices.
 
-The extension uses Ledger's own [Alpine based Docker image](https://github.com/LedgerHQ/ledger-app-builder/blob/master/dev-tools/Dockerfile) to allow developers to setup a build and test environement in a few minutes.
+The extension uses Ledger's own [Alpine based Docker image](https://github.com/LedgerHQ/ledger-app-builder/blob/master/dev-tools/Dockerfile) to allow developers to setup a build and test environment in a few minutes.
 
 * Build your app for all Ledger devices : Nano S, Nano S Plus, Nano X, Stax.
 * Stay up to date with the latest SDK.
@@ -14,7 +14,7 @@ The extension uses Ledger's own [Alpine based Docker image](https://github.com/L
 
 ### Tasks
 
-Automatically add tasks to help you build, test and load your app on a physical device. 
+Automatically add tasks to help you build, test and load your app on a physical device.
 These tasks are accessible through the build task menu keyboard shortcut to avoid clicking around.
 
 <img src="https://github.com/LedgerHQ/ledger-vscode-extension/blob/main/resources/tasks.gif?raw=true" width="70%" height="70%"/>
@@ -47,8 +47,15 @@ This extension contributes the following settings:
 * `ledgerDevTools.onboardingSeed`: Set the device quick onboarding 24-word Seed phrase.
 * `ledgerDevTools.dockerImage`: Set the Ledger developer tools Docker image.
 * `ledgerDevTools.additionalDepsPerApp`: Add dependencies for current app's functional tests (for instance 'apk add python3-protobuf').
+* `ledgerDevTools.keepContainerTerminal`: Indicates to keep the Terminal window opened after a successful Container Update.
+* `ledgerDevTools.containerUpdateRetries`: Set the max number of Container Update retries.
 
 ## Release Notes
+
+## 0.1.6
+
+* Add setting parameter allowing to automatically close the terminal Window when the Container Update is successful.
+* Add setting parameter to set the max number of allowed Container Update retries avoiding the infinite loop.
 
 ## 0.1.5
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "onStartupFinished"
   ],
   "main": "./dist/extension.js",
-  
+
   "contributes": {
     "taskDefinitions": [
         {
@@ -101,6 +101,16 @@
                 "default": {"app-boilerplate": "apk add gcc musl-dev python3-dev"},
                 "scope": "application",
                 "description": "Additional dependencies to install for each app."
+              },
+              "ledgerDevTools.keepContainerTerminal": {
+                "type": "boolean",
+                "default": true,
+                "markdownDescription": "Keep the Terminal window opened after a successful Container Update."
+              },
+              "ledgerDevTools.containerUpdateRetries": {
+                "type": "number",
+                "default": 5,
+                "markdownDescription": "Max number of Container Update retries."
               }
             }
         }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ledger-dev-tools",
   "displayName": "ledger-dev-tools",
   "description": "Tools to accelerate development of apps for Ledger devices.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "publisher": "LedgerHQ",
   "license": "Apache",
   "icon": "resources/ledger-square.png",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,7 +71,7 @@ export function activate(context: vscode.ExtensionContext) {
   vscode.tasks.onDidEndTask((event) => {
     const taskName = event.execution.task.name;
     if (taskName.startsWith("Update Container")) {
-      containerManager.manageContainer();
+      containerManager.checkUpdateRetries();
     }
   });
 


### PR DESCRIPTION
This PR improve the following:
- Add setting to keep Terminal Window opened after a successful _Container Update_
- Add setting for the max number of _Container Update_ retries
- Add a new `containerStatus` function to clean the code
- Hide Terminal Window when the _Container Update_ is done
- Only retry the _Container Update_ if number of retries < max value from settings
- Change version to 0.1.6

This PR also fixes https://github.com/LedgerHQ/ledger-vscode-extension/issues/2

