### PR TITLE
Add `dockerRunArgs` setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2]
+
+### Added
+
+* Added `dockerRunArgs` setting.
+
 ## [0.7.1]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This extension contributes the following settings:
 * `ledgerDevTools.onboardingPin`: Set the device quick onboarding PIN code.
 * `ledgerDevTools.onboardingSeed`: Set the device quick onboarding 24-word Seed phrase.
 * `ledgerDevTools.dockerImage`: Set the Ledger developer tools Docker image.
+* `ledgerDevTools.dockerRunArgs`: Any additional command line args to pass to the `docker run` command for the Ledger developer tools Docker image.
 * `ledgerDevTools.additionalReqsPerApp`: Add prerequisites for current app's functional tests (for instance 'apk add python3-protobuf').
 * `ledgerDevTools.keepTerminal`: Indicates to keep the Terminal window opened after a successful task execution.
 * `ledgerDevTools.containerUpdateRetries`: Set the max number of Container Update retries.
@@ -71,6 +72,10 @@ This extension contributes the following settings:
 * `ledgerDevTools.enableDeviceOpsForNanoX`: Allow device operations on Nano X (requires special development device)
 
 ## Release Notes
+
+## 0.7.2
+
+* Added `dockerRunArgs` setting.
 
 ## 0.7.1
 

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
         },
         "ledgerDevTools.dockerRunArgs": {
           "type": "string",
+          "scope": "resource",
           "default": "",
           "description": "Additional arguments to pass to the 'docker run' command for the Ledger developer tools Docker image."
         },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ledger-dev-tools",
   "displayName": "Ledger Dev Tools",
   "description": "Tools to accelerate development of apps for Ledger devices.",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "publisher": "LedgerHQ",
   "license": "Apache",
   "icon": "resources/ledger-square.png",

--- a/package.json
+++ b/package.json
@@ -165,6 +165,11 @@
           "default": "ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:latest",
           "description": "Ledger developer tools Docker image."
         },
+        "ledgerDevTools.dockerRunArgs": {
+          "type": "string",
+          "default": "",
+          "description": "Additional arguments to pass to the 'docker run' command for the Ledger developer tools Docker image."
+        },
         "ledgerDevTools.onboardingPin": {
           "type": "string",
           "default": "1234",

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -276,18 +276,21 @@ export class TaskProvider implements vscode.TaskProvider {
   private runDevToolsImageExec(): string {
     let exec = "";
 
+    const conf = vscode.workspace.getConfiguration("ledgerDevTools");
+    const dockerRunArgs = conf.get<string>("dockerRunArgs");
+
     if (this.currentApp) {
       // Checks if a container with the name  ${this.containerName} exists, and if it does, it is stopped and removed before a new container is created using the same name and other specified configuration parameters
       if (platform === "linux") {
         // Linux
-        exec = `docker ps -a --format '{{.Names}}' | grep -q  ${this.containerName} && (docker container stop  ${this.containerName} && docker container rm  ${this.containerName}) ; docker pull ${this.image} && docker run --user $(id -u):$(id -g) --privileged -e DISPLAY=$DISPLAY -v '/dev/bus/usb:/dev/bus/usb' -v '/tmp/.X11-unix:/tmp/.X11-unix' -v '${this.workspacePath}:/app' -t -d --name  ${this.containerName} ${this.image}`;
+        exec = `docker ps -a --format '{{.Names}}' | grep -q  ${this.containerName} && (docker container stop  ${this.containerName} && docker container rm  ${this.containerName}) ; docker pull ${this.image} && docker run --user $(id -u):$(id -g) --privileged -e DISPLAY=$DISPLAY -v '/dev/bus/usb:/dev/bus/usb' -v '/tmp/.X11-unix:/tmp/.X11-unix' -v '${this.workspacePath}:/app' ${dockerRunArgs} -t -d --name  ${this.containerName} ${this.image}`;
       } else if (platform === "darwin") {
         // macOS
-        exec = `xhost + ; docker ps -a --format '{{.Names}}' | grep -q  ${this.containerName} && (docker container stop  ${this.containerName} && docker container rm  ${this.containerName}) ; docker pull ${this.image} && docker run --user $(id -u):$(id -g) --privileged -e DISPLAY='host.docker.internal:0' -v '/tmp/.X11-unix:/tmp/.X11-unix' -v '${this.workspacePath}:/app' -t -d --name  ${this.containerName} ${this.image}`;
+        exec = `xhost + ; docker ps -a --format '{{.Names}}' | grep -q  ${this.containerName} && (docker container stop  ${this.containerName} && docker container rm  ${this.containerName}) ; docker pull ${this.image} && docker run --user $(id -u):$(id -g) --privileged -e DISPLAY='host.docker.internal:0' -v '/tmp/.X11-unix:/tmp/.X11-unix' -v '${this.workspacePath}:/app' ${dockerRunArgs} -t -d --name  ${this.containerName} ${this.image}`;
       } else {
         // Assume windows
         const winWorkspacePath = this.workspacePath.substring(1); // Remove first '/' from windows workspace path URI. Otherwise it is not valid.
-        exec = `if (docker ps -a --format '{{.Names}}' | Select-String -Quiet  ${this.containerName}) { docker container stop  ${this.containerName}; docker container rm  ${this.containerName} }; docker pull ${this.image}; docker run --privileged -e DISPLAY='host.docker.internal:0' -v '${winWorkspacePath}:/app' -t -d --name  ${this.containerName} ${this.image}`;
+        exec = `if (docker ps -a --format '{{.Names}}' | Select-String -Quiet  ${this.containerName}) { docker container stop  ${this.containerName}; docker container rm  ${this.containerName} }; docker pull ${this.image}; docker run --privileged -e DISPLAY='host.docker.internal:0' -v '${winWorkspacePath}:/app' ${dockerRunArgs} -t -d --name  ${this.containerName} ${this.image}`;
       }
     }
 


### PR DESCRIPTION
This allows to customize the running container, for example in order to add additional volumes needed during building time, which is a common need when one has a Rust workspace with dependencies imported via relative paths.

Example:

```
{
    "ledgerDevTools": {
        "dockerRunArgs": "-v '${workspaceFolder}/../some_other_crate:/some_other_crate"
    }
}
```