### PR TITLE
Improvements and fixs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0]
+
+### Added
+
+* Add clean 'target' entry to only remove build files for the selected target.
+
+### Changed
+
+* Separate Build Incremental for Rust for clarity
+* Update guideline enforcer to run scan-build on selected target only, or All in loop
+* Update packages used by the extension.
+
+### Fixed
+
+* Fix #69: wrong detection of the SDK (lowercase vs uppercase)
+* Fix #71: obsolete udev rules
+* Robustify docker-compose analyze, using the app current path
+
 ## [1.0.0]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ledger-dev-tools",
-  "version": "0.9.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ledger-dev-tools",
-      "version": "0.9.2",
+      "version": "1.1.0",
       "license": "Apache",
       "dependencies": {
         "@ltd/j-toml": "^1.38.0",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@stylistic/eslint-plugin": "^2.11.0",
         "@types/mocha": "^10.0.10",
-        "@types/node": "22.9.1",
+        "@types/node": "^22.14.1",
         "@types/vscode": "^1.95.0",
         "@typescript-eslint/eslint-plugin": "^8.15.0",
         "@typescript-eslint/parser": "^8.15.0",
@@ -641,13 +641,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.1.tgz",
-      "integrity": "sha512-p8Yy/8sw1caA8CdRIQBG5tiLHmxtQKObCijiAa9Ez+d4+PRffM4054xbju0msf+cvhJpnFEeNjxmVT/0ipktrg==",
+      "version": "22.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.8"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/node-forge": {
@@ -3235,9 +3235,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
-      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5872,9 +5872,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ledger-dev-tools",
   "displayName": "Ledger Dev Tools",
   "description": "Tools to accelerate development of apps for Ledger devices.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "publisher": "LedgerHQ",
   "license": "Apache",
   "icon": "resources/ledger-square.png",
@@ -59,14 +59,14 @@
           "group": "inline"
         },
         {
-            "command": "refreshTests",
-            "when": "view == mainView && viewItem == functionalTests && ledgerDevTools.showRefreshTests",
-            "group": "inline"
+          "command": "refreshTests",
+          "when": "view == mainView && viewItem == functionalTests && ledgerDevTools.showRefreshTests",
+          "group": "inline"
         },
         {
-            "command": "refreshTestsSpin",
-            "when": "view == mainView && viewItem == functionalTests && ledgerDevTools.showRefreshTestsSpin",
-            "group": "inline"
+          "command": "refreshTestsSpin",
+          "when": "view == mainView && viewItem == functionalTests && ledgerDevTools.showRefreshTestsSpin",
+          "group": "inline"
         }
       ]
     },
@@ -97,7 +97,8 @@
       "ledger-tools": [
         {
           "id": "mainView",
-          "name": ""
+          "name": "",
+          "icon": "resources/ledger-square.png"
         }
       ]
     },
@@ -297,13 +298,13 @@
     "deploy": "vsce publish"
   },
   "dependencies": {
-      "@ltd/j-toml": "^1.38.0",
-      "fast-glob": "^3.3.2"
+    "@ltd/j-toml": "^1.38.0",
+    "fast-glob": "^3.3.2"
   },
   "devDependencies": {
     "@stylistic/eslint-plugin": "^2.11.0",
     "@types/mocha": "^10.0.10",
-    "@types/node": "22.9.1",
+    "@types/node": "^22.14.1",
     "@types/vscode": "^1.95.0",
     "@typescript-eslint/eslint-plugin": "^8.15.0",
     "@typescript-eslint/parser": "^8.15.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         },
         {
           "command": "selectCheck",
-          "when": "view == mainView && viewItem == selectCheck && ledgerDevTools.contextAllTargets",
+          "when": "view == mainView && viewItem == selectCheck",
           "group": "inline"
         },
         {
@@ -197,8 +197,7 @@
         "title": "Select a Guideline Enforcer Check",
         "category": "Ledger",
         "tooltip": "Select the check you want to run, or All by default.",
-        "icon": "$(pass)",
-        "enablement": "ledgerDevTools.contextAllTargets"
+        "icon": "$(pass)"
       },
       {
         "command": "rebuildTestUseCaseDeps",

--- a/src/appSelector.ts
+++ b/src/appSelector.ts
@@ -17,7 +17,7 @@ const PYTEST_DETECTION_FILE: string = "conftest.py";
 type AppType = "manifest" | "legacyManifest" | "makefile";
 
 // Define valid app languages
-const validLanguages = ["Rust", "C"] as const;
+const validLanguages = ["rust", "c"] as const;
 // Define the AppLanguage type
 export type AppLanguage = (typeof validLanguages)[number];
 
@@ -197,7 +197,7 @@ export function findAppInFolder(folderUri: vscode.Uri): App | undefined {
   const containerName = `${appFolderName}-container`;
 
   let appName = "unknown";
-  let appLanguage: AppLanguage = "C";
+  let appLanguage: AppLanguage = "c";
   let testsDir = undefined;
   let packageName = undefined;
   let compatibleDevices: LedgerDevice[] = ["Nano S", "Nano S Plus", "Nano X", "Stax", "Flex"];
@@ -223,7 +223,7 @@ export function findAppInFolder(folderUri: vscode.Uri): App | undefined {
         console.log("Found manifest in " + appFolderName);
         let tomlContent = toml.parse(fileContent);
         [appLanguage, buildDirPath, compatibleDevices, testsDir, testsUseCases, buildUseCases] = parseManifest(tomlContent);
-        if (appLanguage === "C") {
+        if (appLanguage === "c") {
           appName = getAppName(folderUri.fsPath);
         }
         else {
@@ -238,7 +238,7 @@ export function findAppInFolder(folderUri: vscode.Uri): App | undefined {
         [buildDirPath, appName, packageName] = parseLegacyRustManifest(tomlContent, appFolderUri);
         testsDir = findFunctionalTestsWithoutManifest(appFolderUri);
         compatibleDevices = ["Nano S", "Nano S Plus", "Nano X"];
-        appLanguage = "Rust";
+        appLanguage = "rust";
         showManifestWarning(appFolderName, true);
         break;
       }
@@ -267,7 +267,7 @@ export function findAppInFolder(folderUri: vscode.Uri): App | undefined {
 
   // Add the app to the list
   if (found) {
-    if (appLanguage === "C") {
+    if (appLanguage === "c") {
       variants = getAppVariants(folderUri.fsPath, appName, appFolderUri);
       if (variants.values.length > 1) {
         vscode.commands.executeCommand("setContext", "ledgerDevTools.showSelectVariant", true);
@@ -712,10 +712,10 @@ export function getAppTestsList(targetSelector: TargetSelector, showMenu: boolea
 
 // Type guard function to check if a string is a valid app language
 function isValidLanguage(value: string): AppLanguage {
-  if (!validLanguages.includes(value as AppLanguage)) {
+  if (!validLanguages.includes(value.toLowerCase() as AppLanguage)) {
     throw new Error(`Invalid language: ${value} in manifest`);
   }
-  return value as AppLanguage;
+  return value.toLowerCase() as AppLanguage;
 }
 
 // Parse Cargo.toml and return app name and package name
@@ -880,7 +880,7 @@ export function getAndBuildAppTestsDependencies(targetSelector: TargetSelector, 
         if (depApp) {
           let depAppBuildUseCase = depApp.buildUseCases?.find(useCase => useCase.name === dep.useCase);
           if (depAppBuildUseCase) {
-            if (depApp.language === "C") {
+            if (depApp.language === "c") {
               console.log(`Ledger: building C app ${depApp.name} in ${depFolderPath}`);
 
               // Execute git command in cmd.exe on host, no docker

--- a/src/targetSelector.ts
+++ b/src/targetSelector.ts
@@ -100,10 +100,6 @@ export class TargetSelector {
       this.selectedSpeculosModel = speculosModels[this.selectedTarget];
       this.selectedSDKModel = this.sdkModelsArray[this.selectedTarget];
       this.selectedTargetId = targetIds[this.selectedTarget];
-      vscode.commands.executeCommand("setContext", "ledgerDevTools.contextAllTargets", true);
-    }
-    else {
-      vscode.commands.executeCommand("setContext", "ledgerDevTools.contextAllTargets", false);
     }
   }
 

--- a/src/targetSelector.ts
+++ b/src/targetSelector.ts
@@ -117,7 +117,7 @@ export class TargetSelector {
       // Define sdkModelsArray based on the targetsArray
       this.targetsArray.forEach((target) => {
         this.sdkModelsArray[target]
-          = target === "Nano S Plus" && currentApp.language === "Rust" ? "nanosplus" : sdkModels[target];
+          = target === "Nano S Plus" && currentApp.language === "rust" ? "nanosplus" : sdkModels[target];
       });
 
       if (this.targetsArray.length > 1) {

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -249,7 +249,7 @@ export class TaskProvider implements vscode.TaskProvider {
       toolTip:
         "Run Guideline Enforcer checks. These checks are also run in the app's repository CI and must pass before the app can be deployed.",
       state: "enabled",
-      allSelectedBehavior: "disable",
+      allSelectedBehavior: "enable",
     },
   ];
 
@@ -709,6 +709,13 @@ export class TaskProvider implements vscode.TaskProvider {
     // Retrieve the selected check, if any
     if (checks.selected !== "All") {
       checkOpt = `-c ${checks.selected}`;
+    }
+
+    if (this.tgtSelector.getSelectedTarget() !== specialAllDevice) {
+      if (checkOpt) {
+        checkOpt += " ";
+      }
+      checkOpt += `-t ${this.tgtSelector.getSelectedSDKModel()}`;
     }
     // Runs checks inside the docker container.
     const exec = `docker exec -it ${userOpt} ${

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -122,8 +122,17 @@ export class TaskProvider implements vscode.TaskProvider {
     },
     {
       group: "Build",
+      name: "Build",
+      builders: { ["rust"]: this.rustBuildExec },
+      toolTip: "Build app",
+      dependsOn: this.appSubmodulesInitExec,
+      state: "enabled",
+      allSelectedBehavior: "executeForEveryTarget",
+    },
+    {
+      group: "Build",
       name: "Build incremental",
-      builders: { ["c"]: this.cBuildExec, ["rust"]: this.rustBuildExec },
+      builders: { ["c"]: this.cBuildExec },
       toolTip: "Build app (incremental mode)",
       dependsOn: this.appSubmodulesInitExec,
       state: "enabled",

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -123,7 +123,7 @@ export class TaskProvider implements vscode.TaskProvider {
     {
       group: "Build",
       name: "Build incremental",
-      builders: { ["C"]: this.cBuildExec, ["Rust"]: this.rustBuildExec },
+      builders: { ["c"]: this.cBuildExec, ["rust"]: this.rustBuildExec },
       toolTip: "Build app (incremental mode)",
       dependsOn: this.appSubmodulesInitExec,
       state: "enabled",
@@ -132,7 +132,7 @@ export class TaskProvider implements vscode.TaskProvider {
     {
       group: "Build",
       name: "Build full",
-      builders: { ["C"]: this.cBuildFullExec },
+      builders: { ["c"]: this.cBuildFullExec },
       toolTip: "Build app (full rebuild)",
       dependsOn: this.appSubmodulesInitExec,
       state: "enabled",
@@ -149,7 +149,7 @@ export class TaskProvider implements vscode.TaskProvider {
     {
       group: "Build",
       name: "Clean all the build files",
-      builders: { ["C"]: this.cCleanAllExec, ["Rust"]: this.rustCleanAllExec },
+      builders: { ["c"]: this.cCleanAllExec, ["rust"]: this.rustCleanAllExec },
       toolTip: "Clean the app build files for all targets",
       state: "enabled",
       allSelectedBehavior: "enable",
@@ -247,7 +247,7 @@ export class TaskProvider implements vscode.TaskProvider {
   constructor(treeProvider: TreeDataProvider, targetSelector: TargetSelector) {
     this.treeProvider = treeProvider;
     this.tgtSelector = targetSelector;
-    this.appLanguage = "C";
+    this.appLanguage = "c";
     this.appName = "";
     this.containerName = "";
     this.workspacePath = "";

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -2,6 +2,7 @@
 
 import * as vscode from "vscode";
 import * as path from "path";
+import * as os from "os";
 import * as fs from "fs";
 import * as fg from "fast-glob";
 import { platform } from "node:process";
@@ -13,8 +14,8 @@ export const taskType = "L";
 
 // Udev rules (for Linux app loading requirements)
 const udevRulesFilePath = "/etc/udev/rules.d/";
-const udevRulesFile = "20-ledger.ledgerblue.rules";
-const udevRules = `SUBSYSTEMS=="usb", KERNEL=="hidraw*", ATTRS{idVendor}=="2c97", MODE="0666", ATTRS{idProduct}=="0006|6000|6001|6002|6003|6004|6005|6006|6007|6008|6009|600a|600b|600c|600d|600e|600f|6010|6011|6012|6013|6014|6015|6016|6017|6018|6019|601a|601b|601c|601d|601e|601f", TAG+="uaccess", TAG+="udev-acl"`;
+const udevRulesUrl = "https://raw.githubusercontent.com/LedgerHQ/udev-rules/master/20-hw1.rules";
+let udevRulesDone: boolean = false;
 
 type CustomTaskFunction = () => void;
 type ExecBuilder = () => string | [string, CustomTaskFunction];
@@ -47,6 +48,25 @@ export async function showChecks() {
     checkSelectedEmitter.fire();
   }
   return result;
+}
+
+// Cache the Promise to ensure the function is only executed once
+let appLoadRequirementsPromise: Promise<string> | null = null;
+
+// Fetch the udev rules file from the URL and write it to a temporary file
+async function fetchUdevRules(): Promise<string> {
+  const response = await fetch(udevRulesUrl);
+  const udevRulesFile = path.basename(udevRulesUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch udev rules: ${response.statusText}`);
+  }
+  const tempFilePath = path.join(os.tmpdir(), udevRulesFile);
+  const rulesContent = await response.text();
+
+  // Write the content to a temporary file
+  fs.writeFileSync(tempFilePath, rulesContent, { encoding: "utf8" });
+
+  return tempFilePath; // Return the path to the temporary file
 }
 
 export interface TaskSpec {
@@ -518,30 +538,93 @@ export class TaskProvider implements vscode.TaskProvider {
     return exec;
   }
 
-  private appLoadRequirementsExec(): string | [string, CustomTaskFunction] {
+  private setUdevRulesLinux(tempFilePath: string) {
+    // Dedicated function to set the udev rules on Linux
+    const udevRulesFile = path.basename(udevRulesUrl);
+    let setUdevRules: boolean = false;
+    if (fs.existsSync(`${udevRulesFilePath}${udevRulesFile}`)) {
+      const existingContent = fs.readFileSync(`${udevRulesFilePath}${udevRulesFile}`, "utf8");
+      const newContent = fs.readFileSync(tempFilePath, "utf8");
+      // Compare the existing content with the new content
+      if (existingContent !== newContent) {
+        setUdevRules = true;
+      }
+      else {
+        console.log("Ledger: udev rules are up to date");
+      }
+    }
+    else {
+      console.log("Ledger: No rules detected");
+      setUdevRules = true;
+    }
+    if (setUdevRules) {
+      // Show the warning message
+      const warningMessage = vscode.window.showWarningMessage(
+        `Udev rules need to be updated for sideloading to be executed properly. Please enter your password in the terminal panel to update ${udevRulesFilePath}${udevRulesFile}.`,
+      );
+
+      // Add a marker to indicate when the command finishes
+      const markerFilePath = path.join(os.tmpdir(), "udev_rules_update_done.marker");
+      const execCommand = `sudo mv ${tempFilePath} ${udevRulesFilePath} && sudo udevadm control --reload-rules && sudo udevadm trigger && echo "done" > ${markerFilePath}`;
+
+      // Check if any terminal exists
+      let terminal: vscode.Terminal;
+      if (vscode.window.terminals.length > 0) {
+        // Reuse the first existing terminal
+        terminal = vscode.window.terminals[0];
+      }
+      else {
+        // Create a new terminal if none exist
+        terminal = vscode.window.createTerminal("Update Udev Rules");
+      }
+      // Send the command (requesting the sudo password) to the terminal
+      terminal.show();
+      terminal.sendText(execCommand);
+
+      // Simulate dismissing the warning message after a delay
+      setTimeout(() => {
+        warningMessage.then(() => {
+          // No action needed, this ensures the message is dismissed
+        });
+      }, 10000);
+
+      // Poll for the marker file and close the terminal when the command is done
+      const checkInterval = setInterval(() => {
+        if (fs.existsSync(markerFilePath)) {
+          clearInterval(checkInterval); // Stop polling
+          fs.unlinkSync(markerFilePath); // Clean up the marker file
+          terminal.dispose(); // Close the terminal
+        }
+      }, 1000); // Check every second
+    }
+  }
+
+  private appLoadRequirementsExec(): string {
     let exec = "";
     if (platform === "linux") {
       // Linux
-      // Copies the ledger udev rule file to the /etc/udev/rules.d/ directory if it does not exist or if the content needs to be updated, then reloads the rules and triggers udev.
-      exec = `if [ ! -f '${udevRulesFilePath}${udevRulesFile}' ] || ! cmp -s '${udevRulesFilePath}${udevRulesFile}' <(echo -n '${udevRules}') ; then echo -n '${udevRules}' > ${udevRulesFile} && sudo mv ${udevRulesFile} ${udevRulesFilePath} && sudo udevadm control --reload-rules && sudo udevadm trigger; fi`;
-      const customFunction = () => {
-        let showSudoMsg: boolean = false;
-        if (fs.existsSync(`${udevRulesFilePath}${udevRulesFile}`)) {
-          const filesContent = fs.readFileSync(`${udevRulesFilePath}${udevRulesFile}`, "utf8");
-          if (filesContent !== udevRules) {
-            showSudoMsg = true;
-          }
+
+      // If the Promise already exists, return it
+      if (appLoadRequirementsPromise) {
+        return "";
+      }
+
+      // Create a new Promise and cache it
+      appLoadRequirementsPromise = new Promise((resolve, reject) => {
+        if (udevRulesDone) {
+          resolve(""); // If rules are already applied, resolve immediately
+          return;
         }
-        else {
-          showSudoMsg = true;
-        }
-        if (showSudoMsg) {
-          vscode.window.showWarningMessage(
-            `Udev rules need to be updated for sideloading to be executed properly. Please enter your password in the terminal panel to update ${udevRulesFilePath}${udevRulesFile}.`,
-          );
-        }
-      };
-      return [exec, customFunction];
+
+        udevRulesDone = true;
+        fetchUdevRules().then((tempFilePath) => {
+          this.setUdevRulesLinux(tempFilePath); // Call the function to set udev rules
+          resolve(""); // Resolve the Promise after execution
+        }).catch((error) => {
+          console.error("Error fetching udev rules:", error);
+          reject(error); // Reject the Promise on error
+        });
+      });
     }
     else if (platform === "darwin") {
       // macOS
@@ -744,12 +827,15 @@ export class TaskProvider implements vscode.TaskProvider {
       let dependFunc: CustomTaskFunction | undefined;
       if (item.dependsOn) {
         let dependResult = item.dependsOn.call(this);
-        if (typeof dependResult === "string") {
-          dependExec = dependResult + " ; ";
-        }
-        else {
-          dependExec = dependResult[0] + " ; ";
-          dependFunc = dependResult[1];
+        // Check if the result is not empty
+        if (dependResult) {
+          if (typeof dependResult === "string") {
+            dependExec = dependResult + " ; ";
+          }
+          else {
+            dependExec = dependResult[0] + " ; ";
+            dependFunc = dependResult[1];
+          }
         }
       }
       const builderResult = item.builders[this.appLanguage]?.call(this) || item.builders["Both"]?.call(this) || "";

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -140,9 +140,17 @@ export class TaskProvider implements vscode.TaskProvider {
     },
     {
       group: "Build",
-      name: "Clean the build files",
-      builders: { ["C"]: this.cCleanExec, ["Rust"]: this.rustCleanExec },
-      toolTip: "Clean the app build files",
+      name: "Clean the target build files",
+      builders: { ["c"]: this.cCleanTargetExec },
+      toolTip: "Clean the app build files for the selected target",
+      state: "enabled",
+      allSelectedBehavior: "disable",
+    },
+    {
+      group: "Build",
+      name: "Clean all the build files",
+      builders: { ["C"]: this.cCleanAllExec, ["Rust"]: this.rustCleanAllExec },
+      toolTip: "Clean the app build files for all targets",
       state: "enabled",
       allSelectedBehavior: "enable",
     },
@@ -444,13 +452,19 @@ export class TaskProvider implements vscode.TaskProvider {
     return exec;
   }
 
-  private cCleanExec(): string {
+  private cCleanTargetExec(): string {
+    // Cleans all app build files (for the selected device model).
+    const exec = `docker exec -it ${this.containerName} bash -c 'export BOLOS_SDK=$(echo ${this.tgtSelector.getSelectedSDK()}) && make -C ${this.buildDir} clean_target'`;
+    return exec;
+  }
+
+  private cCleanAllExec(): string {
     // Cleans all app build files (for all device models).
     const exec = `docker exec -it ${this.containerName} bash -c 'make -C ${this.buildDir} clean'`;
     return exec;
   }
 
-  private rustCleanExec(): string {
+  private rustCleanAllExec(): string {
     // Cleans all app build files (for all device models).
     const exec = `docker exec -it -u 0 ${this.containerName} bash -c 'cd ${this.buildDir} && cargo clean ; rm -rf build'`;
     return exec;

--- a/src/treeView.ts
+++ b/src/treeView.ts
@@ -261,6 +261,11 @@ export class TreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
         else {
           buidUseCaseItem.label = `Build`;
         }
+        // Update clean target label
+        const cleanItem = buidUseCaseItem.children?.find(child => child.label && child.label.toString().startsWith("Clean the "));
+        if (cleanItem) {
+          cleanItem.label = `Clean the ${this.targetSelector.getSelectedTarget()} build files`;
+        }
       }
       if (selectVariantItem) {
         if (currentApp.variants?.values && currentApp.variants?.values.length > 1 && currentApp.variants?.selected) {

--- a/src/treeView.ts
+++ b/src/treeView.ts
@@ -190,6 +190,11 @@ export class TreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
 
   public getComposeServiceName(): string {
     let optionsExecSync: cp.ExecSyncOptions = { stdio: "pipe", encoding: "utf-8" };
+    const currentApp = getSelectedApp();
+    if (currentApp) {
+      const uri = vscode.Uri.parse(currentApp.folderUri.toString());
+      optionsExecSync.cwd = uri.fsPath;
+    }
     // If platform is windows, set shell to powershell for cp exec.
     if (platform === "win32") {
       let shell: string = "C:\\windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";


### PR DESCRIPTION
- Add clean `target <target>` in menu
- Fix #69
- Fix #71
- Robustify docker-compose analyze, using the app current path
- Update guideline enforcer to run scan-build on selected target only, or All in loop
- Update packages version