### PR TITLE
parallel execution for _all_ targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0]
+
+### Added
+
+* Per-target container management: each device model (flex, stax, nanos+, …) now gets its own container named `<app>-<model>`, enabling parallel multi-device workflows.
+* Container panel in the Tools section showing per-container status with stop, clean, and recreate actions.
+* "Select failed tests" button that reads pytest's `lastfailed` cache to re-select previously failing tests.
+* pip cache volume (`ledger-pip-cache`) mounted in all containers to speed up repeated installs.
+
+### Changed
+
+* `Update Container` and `Create Container` tasks now run sequentially across all targets when "All" is selected (avoids concurrent `docker pull` races).
+* pytest commands now pass `--color=yes` for coloured output in the terminal panel.
+
+### Breaking
+
+* The VS Code task type identifier has changed from `"L"` to `"ledger"`. If you have custom `.vscode/tasks.json` entries that reference `"type": "L"`, update them to `"type": "ledger"`.
+
 ## [2.6.0]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ledger-dev-tools",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ledger-dev-tools",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "Apache",
       "dependencies": {
         "@formkit/auto-animate": "^0.9.0",
@@ -1433,9 +1433,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1453,9 +1450,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1473,9 +1467,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1493,9 +1484,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ledger-dev-tools",
   "displayName": "Ledger Dev Tools",
   "description": "Tools to accelerate development of apps for Ledger devices.",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "publisher": "LedgerHQ",
   "license": "Apache",
   "icon": "resources/ledger-square.png",

--- a/src/appSelector.ts
+++ b/src/appSelector.ts
@@ -7,7 +7,7 @@ import { platform } from "node:process";
 import * as cp from "child_process";
 import { getDockerUserOpt } from "./containerManager";
 import { TaskProvider } from "./taskProvider";
-import { LedgerDevice, TargetSelector } from "./targetSelector";
+import { LedgerDevice, TargetSelector, specialAllDevice } from "./targetSelector";
 import { pushError, updateSetting, getSetting } from "./extension";
 import { Webview } from "./webview/webviewProvider";
 const APP_DETECTION_FILES: string[] = ["Makefile", "ledger_app.toml"];
@@ -781,9 +781,18 @@ export function getAppTestsList(targetSelector: TargetSelector, showMenu: boolea
             exit 0
         fi${quotesAroundBashCommand}`;
 
+    // Resolve effective container name: append per-target suffix, falling back
+    // to the first compatible device when 'All' is selected.
+    const baseContainerName = selectedApp!.containerName;
+    const selectedTarget = targetSelector.getSelectedTarget();
+    const containerSuffix = selectedTarget === specialAllDevice
+      ? targetSelector.getFirstCompatibleSpeculosModel()
+      : targetSelector.getSelectedSpeculosModel();
+    const effectiveContainerName = containerSuffix ? `${baseContainerName}-${containerSuffix}` : baseContainerName;
+
     let getTestsListArgs = [
       // Resolve UID and GID on the host
-      "exec", ...getDockerUserOpt().split(" "), selectedApp!.containerName, "bash", "-c",
+      "exec", ...getDockerUserOpt().split(" "), effectiveContainerName, "bash", "-c",
       getTestsListShellScript,
     ];
 

--- a/src/containerManager.ts
+++ b/src/containerManager.ts
@@ -151,15 +151,20 @@ export class ContainerManager {
       const containerNames = this.taskProvider.getTargetContainerNames();
       if (containerNames.length === 0) return DevImageStatus.stopped;
 
+      let hasSyncing = false;
       for (const containerName of containerNames) {
         if (!this.checkContainerExists(containerName)) return DevImageStatus.stopped;
         const command = `docker inspect -f "{{ .State.Status }}" ${containerName}`;
         const containerStatus = execSync(command).toString().trim();
         console.log(`Ledger: Container ${containerName} status is ${containerStatus}`);
-        if (containerStatus === "starting" || containerStatus === "restarting") return DevImageStatus.syncing;
-        if (containerStatus !== "running") return DevImageStatus.stopped;
+        if (containerStatus === "starting" || containerStatus === "restarting") {
+          hasSyncing = true;
+        }
+        else if (containerStatus !== "running") {
+          return DevImageStatus.stopped;
+        }
       }
-      return DevImageStatus.running;
+      return hasSyncing ? DevImageStatus.syncing : DevImageStatus.running;
     }
     catch (error: any) {
       console.log(`Docker error : ${error.message}`);

--- a/src/containerManager.ts
+++ b/src/containerManager.ts
@@ -147,29 +147,58 @@ export class ContainerManager {
   }
 
   public getContainerStatus(): DevImageStatus {
-    const currentApp = getSelectedApp();
     try {
-      if (currentApp) {
-        const containerName = currentApp.containerName;
+      const containerNames = this.taskProvider.getTargetContainerNames();
+      if (containerNames.length === 0) return DevImageStatus.stopped;
 
-        if (this.checkContainerExists(containerName)) {
-          const command = `docker inspect -f "{{ .State.Status }}" ${containerName}`;
-          const containerStatus = execSync(command).toString().trim();
-          console.log(`Ledger: Container ${containerName} status is ${containerStatus}`);
-
-          if (containerStatus === "running") {
-            return DevImageStatus.running;
-          }
-          if (containerStatus === "starting" || containerStatus === "restarting") {
-            return DevImageStatus.syncing;
-          }
-        }
+      for (const containerName of containerNames) {
+        if (!this.checkContainerExists(containerName)) return DevImageStatus.stopped;
+        const command = `docker inspect -f "{{ .State.Status }}" ${containerName}`;
+        const containerStatus = execSync(command).toString().trim();
+        console.log(`Ledger: Container ${containerName} status is ${containerStatus}`);
+        if (containerStatus === "starting" || containerStatus === "restarting") return DevImageStatus.syncing;
+        if (containerStatus !== "running") return DevImageStatus.stopped;
       }
-      return DevImageStatus.stopped;
+      return DevImageStatus.running;
     }
     catch (error: any) {
       console.log(`Docker error : ${error.message}`);
       return DevImageStatus.stopped;
+    }
+  }
+
+  public getContainerStatusFor(containerName: string): "running" | "stopped" | "missing" {
+    try {
+      if (!this.checkContainerExists(containerName)) return "missing";
+      const command = `docker inspect -f "{{ .State.Status }}" ${containerName}`;
+      const status = execSync(command, { stdio: "pipe" }).toString().trim();
+      if (status === "running" || status === "starting" || status === "restarting") return "running";
+      return "stopped";
+    }
+    catch {
+      return "missing";
+    }
+  }
+
+  public stopContainer(containerName: string, onComplete?: () => void): void {
+    exec(`docker stop ${containerName}`, (error) => {
+      if (error) {
+        console.log(`Ledger: Failed to stop container ${containerName}: ${error.message}`);
+      }
+      else {
+        console.log(`Ledger: Container ${containerName} stopped`);
+      }
+      onComplete?.();
+    });
+  }
+
+  public cleanContainer(containerName: string): void {
+    try {
+      execSync(`docker rm ${containerName}`, { stdio: "pipe" });
+      console.log(`Ledger: Container ${containerName} removed`);
+    }
+    catch (error: any) {
+      console.log(`Ledger: Failed to remove container ${containerName}: ${error.message}`);
     }
   }
 
@@ -205,47 +234,46 @@ export class ContainerManager {
     }
 
     if (this.isContainerReady() === false) {
-      const currentApp = getSelectedApp();
-      if (currentApp) {
-        const containerName = currentApp.containerName;
+      const containerNames = this.taskProvider.getTargetContainerNames();
+      if (containerNames.length === 0) return;
 
-        const conf = vscode.workspace.getConfiguration("ledgerDevTools");
-        const autoUpdate: boolean = conf.get<boolean>("dockerAutoUpdate") || false;
+      const conf = vscode.workspace.getConfiguration("ledgerDevTools");
+      const autoUpdate: boolean = conf.get<boolean>("dockerAutoUpdate") || false;
 
-        if (autoUpdate) {
-          console.log(`Ledger: Auto-update is enabled, checking for container updates...`);
+      if (autoUpdate) {
+        console.log(`Ledger: Auto-update is enabled, checking for container updates...`);
+        this.triggerStatusEvent(DevImageStatus.syncing);
+        await this.taskProvider.executeTaskByName("Update Container");
+      }
+      else {
+        const allExist = containerNames.every(name => this.checkContainerExists(name));
+        if (allExist) {
+          console.log(`Ledger: All containers exist but are stopped, restarting...`);
           this.triggerStatusEvent(DevImageStatus.syncing);
-          await this.taskProvider.executeTaskByName("Update Container");
-        }
-        else {
-          // Check if container exists but is just stopped
-          if (this.checkContainerExists(containerName)) {
-            console.log(`Ledger: Container ${containerName} exists but is stopped, restarting...`);
-            this.triggerStatusEvent(DevImageStatus.syncing);
-            try {
+          try {
+            for (const containerName of containerNames) {
               const execOptions: ExecSyncOptionsWithStringEncoding = { stdio: "pipe", encoding: "utf-8" };
               execSync(`docker start ${containerName}`, execOptions);
               console.log(`Ledger: Container ${containerName} restarted successfully`);
-              this.triggerStatusEvent(DevImageStatus.running);
             }
-            catch (error: any) {
-              console.log(`Ledger: Failed to restart container: ${error.message}`);
-              this.triggerStatusEvent(DevImageStatus.stopped);
-            }
+            this.triggerStatusEvent(DevImageStatus.running);
+          }
+          catch (error: any) {
+            console.log(`Ledger: Failed to restart containers: ${error.message}`);
+            this.triggerStatusEvent(DevImageStatus.stopped);
+          }
+        }
+        else {
+          const imageName = this.getDockerImage();
+          if (this.checkImageExists(imageName)) {
+            console.log(`Ledger: Some containers missing, creating from existing image...`);
+            this.triggerStatusEvent(DevImageStatus.syncing);
+            await this.taskProvider.executeTaskByName("Create Container");
           }
           else {
-            // Container doesn't exist, check if image exists to create it
-            const imageName = this.getDockerImage();
-            if (this.checkImageExists(imageName)) {
-              console.log(`Ledger: Container ${containerName} does not exist but image ${imageName} is present. Creating container...`);
-              this.triggerStatusEvent(DevImageStatus.syncing);
-              await this.taskProvider.executeTaskByName("Create Container");
-            }
-            else {
-              console.log(`Ledger: Container ${containerName} and image ${imageName} do not exist. Pulling image and creating container...`);
-              this.triggerStatusEvent(DevImageStatus.syncing);
-              await this.taskProvider.executeTaskByName("Update Container");
-            }
+            console.log(`Ledger: Containers and image missing, pulling image and creating...`);
+            this.triggerStatusEvent(DevImageStatus.syncing);
+            await this.taskProvider.executeTaskByName("Update Container");
           }
         }
       }

--- a/src/containerManager.ts
+++ b/src/containerManager.ts
@@ -149,11 +149,11 @@ export class ContainerManager {
   public getContainerStatus(): DevImageStatus {
     try {
       const containerNames = this.taskProvider.getTargetContainerNames();
-      if (containerNames.length === 0) return DevImageStatus.stopped;
+      if (containerNames.length === 0) { return DevImageStatus.stopped; }
 
       let hasSyncing = false;
       for (const containerName of containerNames) {
-        if (!this.checkContainerExists(containerName)) return DevImageStatus.stopped;
+        if (!this.checkContainerExists(containerName)) { return DevImageStatus.stopped; }
         const command = `docker inspect -f "{{ .State.Status }}" ${containerName}`;
         const containerStatus = execSync(command).toString().trim();
         console.log(`Ledger: Container ${containerName} status is ${containerStatus}`);
@@ -174,10 +174,10 @@ export class ContainerManager {
 
   public getContainerStatusFor(containerName: string): "running" | "stopped" | "missing" {
     try {
-      if (!this.checkContainerExists(containerName)) return "missing";
+      if (!this.checkContainerExists(containerName)) { return "missing"; }
       const command = `docker inspect -f "{{ .State.Status }}" ${containerName}`;
       const status = execSync(command, { stdio: "pipe" }).toString().trim();
-      if (status === "running" || status === "starting" || status === "restarting") return "running";
+      if (status === "running" || status === "starting" || status === "restarting") { return "running"; }
       return "stopped";
     }
     catch {
@@ -240,7 +240,7 @@ export class ContainerManager {
 
     if (this.isContainerReady() === false) {
       const containerNames = this.taskProvider.getTargetContainerNames();
-      if (containerNames.length === 0) return;
+      if (containerNames.length === 0) { return; }
 
       const conf = vscode.workspace.getConfiguration("ledgerDevTools");
       const autoUpdate: boolean = conf.get<boolean>("dockerAutoUpdate") || false;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,7 +39,7 @@ import {
   getAppUseCaseNames,
   showAppSelectorMenu,
 } from "./appSelector";
-import { Webview, WebviewRefreshOptions } from "./webview/webviewProvider";
+import { Webview, WebviewRefreshOptions, ContainerTargetInfo } from "./webview/webviewProvider";
 import { runAIReview } from "./aiReviewer";
 import { Wizard } from "./wizard";
 
@@ -88,6 +88,16 @@ export function activate(context: vscode.ExtensionContext) {
 
   new Wizard(context, webview);
 
+  const sendContainerStatuses = () => {
+    const details = taskProvider.getTargetContainerDetails();
+    const statuses: ContainerTargetInfo[] = details.map(({ containerName, model }) => ({
+      containerName,
+      model,
+      status: containerManager.getContainerStatusFor(containerName),
+    }));
+    webview.refresh({ containerStatuses: statuses });
+  };
+
   // Helper to build full webview refresh options from current state
   const buildFullRefreshOptions = (): WebviewRefreshOptions => {
     const appList = getAppList();
@@ -121,6 +131,11 @@ export function activate(context: vscode.ExtensionContext) {
     // Use cached docker status and default values,
     // Status events will update the webview.
     options.containerStatus = containerManager.getContainerStatus();
+    options.containerStatuses = taskProvider.getTargetContainerDetails().map(({ containerName, model }) => ({
+      containerName,
+      model,
+      status: containerManager.getContainerStatusFor(containerName),
+    }));
     options.dockerRunning = dockerRunning;
     options.imageOutdated = false;
     return options;
@@ -150,6 +165,7 @@ export function activate(context: vscode.ExtensionContext) {
         containerStatus: data,
         dockerRunning,
       });
+      sendContainerStatuses();
       if (data === DevImageStatus.running) {
         // Check image outdated in the background (hits Docker registry).
         // Result arrives via onImageOutdatedEvent.
@@ -341,9 +357,12 @@ export function activate(context: vscode.ExtensionContext) {
         statusBarManager.updateTargetItem(target);
       }
 
+      // updateTargetsInfos() must run first: it populates targetsArray from the app's
+      // compatible devices, which containerManager and taskProvider both need to compute
+      // per-target container names (e.g. app-foo-container-flex).
+      targetSelector.updateTargetsInfos();
       containerManager.manageContainer();
       taskProvider.generateTasks();
-      targetSelector.updateTargetsInfos();
       const appList = getAppList();
       webview.refresh({
         apps: {
@@ -404,6 +423,19 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand("executeTask", (taskName: string) => {
       taskProvider.executeTaskByName(taskName);
+    }),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("ledgerDevTools.stopContainer", (containerName: string) => {
+      containerManager.stopContainer(containerName, sendContainerStatuses);
+    }),
+    vscode.commands.registerCommand("ledgerDevTools.cleanContainer", (containerName: string) => {
+      containerManager.cleanContainer(containerName);
+      sendContainerStatuses();
+    }),
+    vscode.commands.registerCommand("ledgerDevTools.executeTaskForTarget", (taskName: string, model: string) => {
+      taskProvider.executeTaskForTarget(taskName, model);
     }),
   );
 

--- a/src/targetSelector.ts
+++ b/src/targetSelector.ts
@@ -226,6 +226,11 @@ export class TargetSelector {
     return firstDevice ? speculosModels[firstDevice] : (this.selectedSpeculosModel ?? "");
   }
 
+  // Pure lookup — returns the speculos model for any target without changing state.
+  public getSpeculosModelForTarget(target: string): string {
+    return speculosModels[target] ?? "";
+  }
+
   public getSelectedSDKModel() {
     return this.selectedSDKModel;
   }

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -110,7 +110,7 @@ export class TaskProvider implements vscode.TaskProvider {
   // All exec builders use ${this.containerName} and automatically get the per-target name.
   // When "All" is selected outside a per-target loop, falls back to the first target.
   private get containerName(): string {
-    if (!this.baseContainerName) return "";
+    if (!this.baseContainerName) { return ""; }
     const target = this.tgtSelector.getSelectedTarget();
     if (target === specialAllDevice) {
       const firstTarget = this.tgtSelector.getTargetsArray().find(t => t !== specialAllDevice);
@@ -124,7 +124,7 @@ export class TaskProvider implements vscode.TaskProvider {
   // Returns all relevant per-target container names for the current selection.
   // Used by ContainerManager for status checks and container lifecycle management.
   public getTargetContainerNames(): string[] {
-    if (!this.baseContainerName) return [];
+    if (!this.baseContainerName) { return []; }
     if (this.tgtSelector.getSelectedTarget() === specialAllDevice) {
       return this.tgtSelector.getTargetsArray()
         .filter(t => t !== specialAllDevice)
@@ -489,7 +489,7 @@ export class TaskProvider implements vscode.TaskProvider {
   }
 
   public getTargetContainerDetails(): { containerName: string; model: string }[] {
-    if (!this.baseContainerName) return [];
+    if (!this.baseContainerName) { return []; }
     return this.tgtSelector.getTargetsArray()
       .filter(t => t !== specialAllDevice)
       .map((t) => {
@@ -505,10 +505,10 @@ export class TaskProvider implements vscode.TaskProvider {
     const target = this.tgtSelector.getTargetsArray().find(
       t => t !== specialAllDevice && this.tgtSelector.getSpeculosModelForTarget(t) === targetModel,
     );
-    if (!target || !this.currentApp) return;
+    if (!target || !this.currentApp) { return; }
 
     const spec = this.taskSpecs.find(s => s.name === taskName);
-    if (!spec) return;
+    if (!spec) { return; }
 
     const savedTarget = this.tgtSelector.getSelectedTarget();
     this.tgtSelector.setSelectedTargetTransient(target);
@@ -1060,9 +1060,23 @@ export class TaskProvider implements vscode.TaskProvider {
           // Restore in-memory state to "All" — no settings write needed here since the
           // caller already persisted "All" before generateTasks() was invoked.
           this.tgtSelector.setSelectedTargetTransient(specialAllDevice);
-          exec = item.parallelWhenAll === false
-            ? parts.map((p, i) => `printf '\\n=== [${labels[i]}] ===\\n' ; ${p}`).join(" ; ")
-            : parts.map((p, i) => `({ ${p.replace(/ -it /g, " -i ")}; } 2>&1 | awk '{print "[${labels[i]}] "$0}')`).join(" & ") + " & wait";
+          if (platform === "win32") {
+            // PowerShell has no printf/awk/&/wait; run targets sequentially with Write-Host labels.
+            exec = parts.map((p, i) => `Write-Host "=== [${labels[i]}] ==="; ${p}`).join("; ");
+          }
+          else if (item.parallelWhenAll === false) {
+            exec = parts.map((p, i) => `printf '\\n=== [${labels[i]}] ===\\n' ; ${p}`).join(" ; ");
+          }
+          else {
+            // Parallel: background each target, capture PIDs, aggregate exit codes.
+            // set -o pipefail inside each subshell ensures pytest's exit code survives the awk pipe.
+            const cmds = parts.map((p, i) =>
+              `(set -o pipefail; { ${p.replace(/ -it /g, " -i ")}; } 2>&1 | awk '{print "[${labels[i]}] "$0}')`,
+            );
+            const launch = cmds.map((c, i) => `${c} & pid${i}=$!`).join("; ");
+            const waits = cmds.map((_, i) => `wait $pid${i} || rc=$?`).join("; ");
+            exec = `${launch}; rc=0; ${waits}; exit $rc`;
+          }
           customFunction = undefined;
         }
 

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -15,7 +15,7 @@ import { debug } from "vscode";
 
 export type { TaskSpec };
 
-export const taskType = "L";
+export const taskType = "ledger";
 
 // Udev rules (for Linux app loading requirements)
 const udevRulesFilePath = "/etc/udev/rules.d/";
@@ -104,7 +104,38 @@ export class TaskProvider implements vscode.TaskProvider {
   private additionalReqs?: string;
   private buildDir: string;
   private workspacePath: string;
-  private containerName: string;
+  private baseContainerName: string = "";
+
+  // Computed from baseContainerName + currently selected target's speculos model.
+  // All exec builders use ${this.containerName} and automatically get the per-target name.
+  // When "All" is selected outside a per-target loop, falls back to the first target.
+  private get containerName(): string {
+    if (!this.baseContainerName) return "";
+    const target = this.tgtSelector.getSelectedTarget();
+    if (target === specialAllDevice) {
+      const firstTarget = this.tgtSelector.getTargetsArray().find(t => t !== specialAllDevice);
+      const model = firstTarget ? this.tgtSelector.getSpeculosModelForTarget(firstTarget) : "";
+      return model ? `${this.baseContainerName}-${model}` : this.baseContainerName;
+    }
+    const model = this.tgtSelector.getSelectedSpeculosModel();
+    return model ? `${this.baseContainerName}-${model}` : this.baseContainerName;
+  }
+
+  // Returns all relevant per-target container names for the current selection.
+  // Used by ContainerManager for status checks and container lifecycle management.
+  public getTargetContainerNames(): string[] {
+    if (!this.baseContainerName) return [];
+    if (this.tgtSelector.getSelectedTarget() === specialAllDevice) {
+      return this.tgtSelector.getTargetsArray()
+        .filter(t => t !== specialAllDevice)
+        .map(t => {
+          const model = this.tgtSelector.getSpeculosModelForTarget(t);
+          return model ? `${this.baseContainerName}-${model}` : this.baseContainerName;
+        });
+    }
+    return [this.containerName];
+  }
+
   private appFolderUri?: vscode.Uri;
   private appName: string;
   private appLanguage: AppLanguage;
@@ -124,7 +155,8 @@ export class TaskProvider implements vscode.TaskProvider {
       builders: { ["Both"]: this.runDevToolsImageExec },
       toolTip: "Update docker container (pull image and restart container)",
       state: "enabled",
-      allSelectedBehavior: "enable",
+      allSelectedBehavior: "executeForEveryTarget",
+      parallelWhenAll: false,
     },
     {
       group: "Tools",
@@ -133,7 +165,8 @@ export class TaskProvider implements vscode.TaskProvider {
       builders: { ["Both"]: this.createContainerExec },
       toolTip: "Create docker container from existing local image (without pulling)",
       state: "enabled",
-      allSelectedBehavior: "enable",
+      allSelectedBehavior: "executeForEveryTarget",
+      parallelWhenAll: false,
     },
     {
       group: "Tools",
@@ -309,7 +342,7 @@ export class TaskProvider implements vscode.TaskProvider {
     this.tgtSelector = targetSelector;
     this.appLanguage = "c";
     this.appName = "";
-    this.containerName = "";
+    this.baseContainerName = "";
     this.workspacePath = "";
     this.buildDir = "";
     this.currentApp = getSelectedApp();
@@ -330,7 +363,7 @@ export class TaskProvider implements vscode.TaskProvider {
   }
 
   private resetVars() {
-    this.containerName = "";
+    this.baseContainerName = "";
     this.workspacePath = "";
     this.buildDir = "";
     this.functionalTestsDir = undefined;
@@ -361,7 +394,7 @@ export class TaskProvider implements vscode.TaskProvider {
 
       this.appName = this.currentApp.name;
       this.appLanguage = this.currentApp.language;
-      this.containerName = this.currentApp.containerName;
+      this.baseContainerName = this.currentApp.containerName;
       this.appFolderUri = this.currentApp.folderUri;
       this.buildDir = this.currentApp.buildDirPath;
       this.workspacePath = this.currentApp.folderUri.path;
@@ -455,6 +488,50 @@ export class TaskProvider implements vscode.TaskProvider {
     return this.tasks.find(task => task.name === taskName);
   }
 
+  public getTargetContainerDetails(): { containerName: string; model: string }[] {
+    if (!this.baseContainerName) return [];
+    return this.tgtSelector.getTargetsArray()
+      .filter(t => t !== specialAllDevice)
+      .map(t => {
+        const model = this.tgtSelector.getSpeculosModelForTarget(t);
+        return {
+          containerName: model ? `${this.baseContainerName}-${model}` : this.baseContainerName,
+          model,
+        };
+      });
+  }
+
+  public executeTaskForTarget(taskName: string, targetModel: string): void {
+    const target = this.tgtSelector.getTargetsArray().find(
+      t => t !== specialAllDevice && this.tgtSelector.getSpeculosModelForTarget(t) === targetModel,
+    );
+    if (!target || !this.currentApp) return;
+
+    const spec = this.taskSpecs.find(s => s.name === taskName);
+    if (!spec) return;
+
+    const savedTarget = this.tgtSelector.getSelectedTarget();
+    this.tgtSelector.setSelectedTargetTransient(target);
+
+    const builderResult = spec.builders[this.appLanguage]?.call(this) || spec.builders["Both"]?.call(this) || "";
+    const exec = typeof builderResult === "string" ? builderResult : builderResult[0];
+
+    this.tgtSelector.setSelectedTargetTransient(savedTarget);
+
+    if (exec) {
+      const task = new MyTask(
+        { type: taskType, task: taskName },
+        vscode.TaskScope.Workspace,
+        taskName,
+        taskType,
+        new vscode.ShellExecution(exec),
+        undefined,
+      );
+      task.group = vscode.TaskGroup.Build;
+      vscode.tasks.executeTask(task);
+    }
+  }
+
   public async executeTaskByName(taskName: string) {
     // Wait for tasks to be generated (promise is created in constructor)
     await this.tasksReadyPromise;
@@ -476,16 +553,16 @@ export class TaskProvider implements vscode.TaskProvider {
       // Pull image first, then stop and remove existing container if it exists, finally create new container
       if (platform === "linux") {
         // Linux
-        exec = `xhost + ; docker pull ${this.image} && (docker ps -a --format '{{.Names}}' | grep -q ${this.containerName} && (docker container stop ${this.containerName} && docker container rm ${this.containerName}) || true) && docker run ${dockerRunOpts} --privileged -e DISPLAY=$DISPLAY -v '/dev/bus/usb:/dev/bus/usb' -v '/tmp/.X11-unix:/tmp/.X11-unix' -v '${this.workspacePath}:/app' ${this.dockerRunArgs} -t -d --name ${this.containerName} ${this.image}`;
+        exec = `xhost + ; docker pull ${this.image} && (docker ps -a --format '{{.Names}}' | grep -q ${this.containerName} && (docker container stop ${this.containerName} && docker container rm ${this.containerName}) || true) && docker run ${dockerRunOpts} --privileged -e DISPLAY=$DISPLAY -v '/dev/bus/usb:/dev/bus/usb' -v '/tmp/.X11-unix:/tmp/.X11-unix' -v '${this.workspacePath}:/app' ${this.dockerRunArgs} -v ledger-pip-cache:/pip-cache -e PIP_CACHE_DIR=/pip-cache -t -d --name ${this.containerName} ${this.image}`;
       }
       else if (platform === "darwin") {
         // macOS
-        exec = `xhost + ; docker pull ${this.image} && (docker ps -a --format '{{.Names}}' | grep -q ${this.containerName} && (docker container stop ${this.containerName} && docker container rm ${this.containerName}) || true) && docker run ${dockerRunOpts} --privileged -e DISPLAY='host.docker.internal:0' -v '/tmp/.X11-unix:/tmp/.X11-unix' -v '${this.workspacePath}:/app' ${this.dockerRunArgs} -t -d --name ${this.containerName} ${this.image}`;
+        exec = `xhost + ; docker pull ${this.image} && (docker ps -a --format '{{.Names}}' | grep -q ${this.containerName} && (docker container stop ${this.containerName} && docker container rm ${this.containerName}) || true) && docker run ${dockerRunOpts} --privileged -e DISPLAY='host.docker.internal:0' -v '/tmp/.X11-unix:/tmp/.X11-unix' -v '${this.workspacePath}:/app' ${this.dockerRunArgs} -v ledger-pip-cache:/pip-cache -e PIP_CACHE_DIR=/pip-cache -t -d --name ${this.containerName} ${this.image}`;
       }
       else {
         // Assume windows
         const winWorkspacePath = this.workspacePath.substring(1); // Remove first '/' from windows workspace path URI. Otherwise it is not valid.
-        exec = `docker pull ${this.image}; if (docker ps -a --format '{{.Names}}' | Select-String -Quiet ${this.containerName}) { docker container stop ${this.containerName}; docker container rm ${this.containerName} }; docker run ${dockerRunOpts} --privileged -e DISPLAY='host.docker.internal:0' -v '${winWorkspacePath}:/app' ${this.dockerRunArgs} -t -d --name ${this.containerName} ${this.image}`;
+        exec = `docker pull ${this.image}; if (docker ps -a --format '{{.Names}}' | Select-String -Quiet ${this.containerName}) { docker container stop ${this.containerName}; docker container rm ${this.containerName} }; docker run ${dockerRunOpts} --privileged -e DISPLAY='host.docker.internal:0' -v '${winWorkspacePath}:/app' ${this.dockerRunArgs} -v ledger-pip-cache:/pip-cache -e PIP_CACHE_DIR=/pip-cache -t -d --name ${this.containerName} ${this.image}`;
       }
     }
 
@@ -501,16 +578,16 @@ export class TaskProvider implements vscode.TaskProvider {
       // Creates container from existing local image without pulling (removes existing container first if needed)
       if (platform === "linux") {
         // Linux
-        exec = `xhost + ; (docker ps -a --format '{{.Names}}' | grep -q ${this.containerName} && (docker container stop ${this.containerName} && docker container rm ${this.containerName}) || true) && docker run ${dockerRunOpts} --privileged -e DISPLAY=$DISPLAY -v '/dev/bus/usb:/dev/bus/usb' -v '/tmp/.X11-unix:/tmp/.X11-unix' -v '${this.workspacePath}:/app' ${this.dockerRunArgs} -t -d --name ${this.containerName} ${this.image}`;
+        exec = `xhost + ; (docker ps -a --format '{{.Names}}' | grep -q ${this.containerName} && (docker container stop ${this.containerName} && docker container rm ${this.containerName}) || true) && docker run ${dockerRunOpts} --privileged -e DISPLAY=$DISPLAY -v '/dev/bus/usb:/dev/bus/usb' -v '/tmp/.X11-unix:/tmp/.X11-unix' -v '${this.workspacePath}:/app' ${this.dockerRunArgs} -v ledger-pip-cache:/pip-cache -e PIP_CACHE_DIR=/pip-cache -t -d --name ${this.containerName} ${this.image}`;
       }
       else if (platform === "darwin") {
         // macOS
-        exec = `xhost + ; (docker ps -a --format '{{.Names}}' | grep -q ${this.containerName} && (docker container stop ${this.containerName} && docker container rm ${this.containerName}) || true) && docker run ${dockerRunOpts} --privileged -e DISPLAY='host.docker.internal:0' -v '/tmp/.X11-unix:/tmp/.X11-unix' -v '${this.workspacePath}:/app' ${this.dockerRunArgs} -t -d --name ${this.containerName} ${this.image}`;
+        exec = `xhost + ; (docker ps -a --format '{{.Names}}' | grep -q ${this.containerName} && (docker container stop ${this.containerName} && docker container rm ${this.containerName}) || true) && docker run ${dockerRunOpts} --privileged -e DISPLAY='host.docker.internal:0' -v '/tmp/.X11-unix:/tmp/.X11-unix' -v '${this.workspacePath}:/app' ${this.dockerRunArgs} -v ledger-pip-cache:/pip-cache -e PIP_CACHE_DIR=/pip-cache -t -d --name ${this.containerName} ${this.image}`;
       }
       else {
         // Assume windows
         const winWorkspacePath = this.workspacePath.substring(1); // Remove first '/' from windows workspace path URI. Otherwise it is not valid.
-        exec = `if (docker ps -a --format '{{.Names}}' | Select-String -Quiet ${this.containerName}) { docker container stop ${this.containerName}; docker container rm ${this.containerName} }; docker run ${dockerRunOpts} --privileged -e DISPLAY='host.docker.internal:0' -v '${winWorkspacePath}:/app' ${this.dockerRunArgs} -t -d --name ${this.containerName} ${this.image}`;
+        exec = `if (docker ps -a --format '{{.Names}}' | Select-String -Quiet ${this.containerName}) { docker container stop ${this.containerName}; docker container rm ${this.containerName} }; docker run ${dockerRunOpts} --privileged -e DISPLAY='host.docker.internal:0' -v '${winWorkspacePath}:/app' ${this.dockerRunArgs} -v ledger-pip-cache:/pip-cache -e PIP_CACHE_DIR=/pip-cache -t -d --name ${this.containerName} ${this.image}`;
       }
     }
 
@@ -858,28 +935,28 @@ export class TaskProvider implements vscode.TaskProvider {
   private functionalTestsExec(): string {
     let [testTarget, execQuotes] = this.getSelectedTests();
     const verboseOpt = getVerboseTests() ? "-s " : "";
-    const exec = `docker exec ${getDockerUserOpt()} -it ${this.containerName} bash -c ${execQuotes}source /opt/venv/bin/activate &&pytest ${testTarget} --tb=short -v ${verboseOpt}--device ${this.tgtSelector.getSelectedSpeculosModel()}${execQuotes}`;
+    const exec = `docker exec ${getDockerUserOpt()} -it ${this.containerName} bash -c ${execQuotes}source /opt/venv/bin/activate &&pytest ${testTarget} --color=yes --tb=short -v ${verboseOpt}--device ${this.tgtSelector.getSelectedSpeculosModel()}${execQuotes}`;
     return exec;
   }
 
   private functionalTestsDisplayExec(): string {
     let [testTarget, execQuotes] = this.getSelectedTests();
     const verboseOpt = getVerboseTests() ? "-s " : "";
-    const exec = `docker exec ${getDockerUserOpt()} -it ${this.containerName} bash -c ${execQuotes}source /opt/venv/bin/activate && pytest ${testTarget} --tb=short -v ${verboseOpt}--device ${this.tgtSelector.getSelectedSpeculosModel()} --display${execQuotes}`;
+    const exec = `docker exec ${getDockerUserOpt()} -it ${this.containerName} bash -c ${execQuotes}source /opt/venv/bin/activate && pytest ${testTarget} --color=yes --tb=short -v ${verboseOpt}--device ${this.tgtSelector.getSelectedSpeculosModel()} --display${execQuotes}`;
     return exec;
   }
 
   private functionalTestsGoldenRunExec(): string {
     let [testTarget, execQuotes] = this.getSelectedTests();
     const verboseOpt = getVerboseTests() ? "-s " : "";
-    const exec = `docker exec ${getDockerUserOpt()} -it ${this.containerName} bash -c ${execQuotes}source /opt/venv/bin/activate && pytest ${testTarget} --tb=short -v ${verboseOpt}--device ${this.tgtSelector.getSelectedSpeculosModel()} --golden_run${execQuotes}`;
+    const exec = `docker exec ${getDockerUserOpt()} -it ${this.containerName} bash -c ${execQuotes}source /opt/venv/bin/activate && pytest ${testTarget} --color=yes --tb=short -v ${verboseOpt}--device ${this.tgtSelector.getSelectedSpeculosModel()} --golden_run${execQuotes}`;
     return exec;
   }
 
   private functionalTestsDisplayOnDeviceExec(): string {
     let [testTarget, execQuotes] = this.getSelectedTests();
     const verboseOpt = getVerboseTests() ? "-s " : "";
-    const exec = `docker exec ${getDockerUserOpt()} -it ${this.containerName} bash -c ${execQuotes}source /opt/venv/bin/activate && pytest ${testTarget} --tb=short -v ${verboseOpt}--device ${this.tgtSelector.getSelectedSpeculosModel()} --display --backend ledgerwallet${execQuotes}`;
+    const exec = `docker exec ${getDockerUserOpt()} -it ${this.containerName} bash -c ${execQuotes}source /opt/venv/bin/activate && pytest ${testTarget} --color=yes --tb=short -v ${verboseOpt}--device ${this.tgtSelector.getSelectedSpeculosModel()} --display --backend ledgerwallet${execQuotes}`;
     return exec;
   }
 
@@ -968,19 +1045,24 @@ export class TaskProvider implements vscode.TaskProvider {
         exec = defineResult[0];
         customFunction = defineResult[1];
         // If the selected target is all and the task behavior is to be executed for all targets,
-        // define the exec for all targets of the app
+        // build one exec per target and run them in parallel (each in its own container).
         if (this.tgtSelector.getSelectedTarget() === specialAllDevice && item.allSelectedBehavior === "executeForEveryTarget") {
-          exec = "";
+          const parts: string[] = [];
+          const labels: string[] = [];
           this.tgtSelector.getTargetsArray().forEach((target) => {
             // Use transient setter: builds per-device exec strings without persisting
             // intermediate device selections to settings (avoids async conf.update races
             // that could corrupt the stored "All" value).
             this.tgtSelector.setSelectedTargetTransient(target);
-            exec += defineExec(item)[0] + " ; ";
+            parts.push(defineExec(item)[0]);
+            labels.push(this.tgtSelector.getSelectedSpeculosModel());
           });
           // Restore in-memory state to "All" — no settings write needed here since the
           // caller already persisted "All" before generateTasks() was invoked.
           this.tgtSelector.setSelectedTargetTransient(specialAllDevice);
+          exec = item.parallelWhenAll === false
+            ? parts.map((p, i) => `printf '\\n=== [${labels[i]}] ===\\n' ; ${p}`).join(" ; ")
+            : parts.map((p, i) => `({ ${p.replace(/ -it /g, " -i ")}; } 2>&1 | awk '{print "[${labels[i]}] "$0}')`).join(" & ") + " & wait";
           customFunction = undefined;
         }
 

--- a/src/taskProvider.ts
+++ b/src/taskProvider.ts
@@ -128,7 +128,7 @@ export class TaskProvider implements vscode.TaskProvider {
     if (this.tgtSelector.getSelectedTarget() === specialAllDevice) {
       return this.tgtSelector.getTargetsArray()
         .filter(t => t !== specialAllDevice)
-        .map(t => {
+        .map((t) => {
           const model = this.tgtSelector.getSpeculosModelForTarget(t);
           return model ? `${this.baseContainerName}-${model}` : this.baseContainerName;
         });
@@ -492,7 +492,7 @@ export class TaskProvider implements vscode.TaskProvider {
     if (!this.baseContainerName) return [];
     return this.tgtSelector.getTargetsArray()
       .filter(t => t !== specialAllDevice)
-      .map(t => {
+      .map((t) => {
         const model = this.tgtSelector.getSpeculosModelForTarget(t);
         return {
           containerName: model ? `${this.baseContainerName}-${model}` : this.baseContainerName,

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,9 @@ export interface TaskSpec {
   state: TaskState;
   allSelectedBehavior: BehaviorWhenAllTargetsSelected;
   mainCommand?: boolean;
+  // When false, "executeForEveryTarget" runs targets sequentially (;) instead of in parallel (&).
+  // Defaults to true. Set false for tasks like container creation where concurrent docker pull races.
+  parallelWhenAll?: boolean;
 }
 
 // Container types

--- a/src/webview/Webview.svelte
+++ b/src/webview/Webview.svelte
@@ -26,6 +26,7 @@
   let dockerRunning = $state(false);
   let imageOutdated = $state(false);
 
+  // Mirror of ContainerTargetInfo in webviewProvider.ts — keep in sync.
   type ContainerTargetStatus = "running" | "stopped" | "missing";
   interface ContainerTargetInfo { model: string; containerName: string; status: ContainerTargetStatus; }
   let containerStatuses = $state<ContainerTargetInfo[]>([]);
@@ -965,8 +966,8 @@
     flex-shrink: 0;
   }
 
-  .ct-dot--running { color: #4caf50; }
-  .ct-dot--stopped { color: #ff9800; }
+  .ct-dot--running { color: var(--vscode-testing-iconPassed); }
+  .ct-dot--stopped { color: var(--vscode-editorWarning-foreground); }
   .ct-dot--missing { color: var(--vscode-disabledForeground, #666); }
 
   .ct-btn {

--- a/src/webview/Webview.svelte
+++ b/src/webview/Webview.svelte
@@ -26,6 +26,11 @@
   let dockerRunning = $state(false);
   let imageOutdated = $state(false);
 
+  type ContainerTargetStatus = "running" | "stopped" | "missing";
+  interface ContainerTargetInfo { model: string; containerName: string; status: ContainerTargetStatus; }
+  let containerStatuses = $state<ContainerTargetInfo[]>([]);
+  let containersExpanded = $state(false);
+
   // Build use case
   let buildUseCase = $state("");
   let buildUseCases = $state<string[]>([]);
@@ -207,6 +212,10 @@
     vscode.postMessage({ command: "refreshTests" });
   }
 
+  function selectFailedTests() {
+    vscode.postMessage({ command: "selectFailedTests" });
+  }
+
   function selectBuildUseCase(useCase: string) {
     buildUseCase = useCase;
     vscode.postMessage({
@@ -359,6 +368,9 @@
         containerStatus = message.status;
         dockerRunning = message.dockerRunning ?? false;
         imageOutdated = message.imageOutdated ?? false;
+        break;
+      case "containerStatuses":
+        containerStatuses = message.statuses ?? [];
         break;
       case "addEnforcerChecks":
         enforcerChecks = [];
@@ -621,6 +633,7 @@
                     {isRefreshing}
                     {refreshTests}
                     {sendSelectedTests}
+                    {selectFailedTests}
                   />
                 </ActionGroup>
               {:else if group.id === "Tools"}
@@ -632,6 +645,46 @@
                   onTogglePin={(actionId) => togglePin(group.id, actionId)}
                   onToggleExpand={() => toggleExpand(group.id)}
                 >
+                  {#snippet headerSuffix()}
+                    {#if containerStatuses.length > 0}
+                      <div class="containers-section">
+                        <button
+                          class="containers-toggle"
+                          onclick={() => (containersExpanded = !containersExpanded)}
+                        >
+                          {#if containersExpanded}
+                            <ChevronDown size={11} />
+                          {:else}
+                            <ChevronRight size={11} />
+                          {/if}
+                          <span>Containers</span>
+                        </button>
+                        {#if containersExpanded}
+                          <div class="containers-rows" use:autoAnimate>
+                            {#each containerStatuses as ct}
+                              <div class="container-row">
+                                <span class="ct-model">{ct.model}</span>
+                                <span class="ct-dot ct-dot--{ct.status}">●</span>
+                                <button
+                                  class="ct-btn ct-btn--primary"
+                                  onclick={() => executeCommand("ledgerDevTools.executeTaskForTarget", ["Create Container", ct.model])}
+                                >
+                                  {ct.status === "missing" ? "CREATE" : "RECREATE"}
+                                </button>
+                                <button
+                                  class="ct-btn ct-btn--secondary"
+                                  disabled={ct.status === "missing"}
+                                  onclick={() => executeCommand(ct.status === "running" ? "ledgerDevTools.stopContainer" : "ledgerDevTools.cleanContainer", [ct.containerName])}
+                                >
+                                  {ct.status === "running" ? "STOP" : "CLEAN"}
+                                </button>
+                              </div>
+                            {/each}
+                          </div>
+                        {/if}
+                      </div>
+                    {/if}
+                  {/snippet}
                   {#snippet optionSuffix(option)}
                     {#if option.label === "Enforcer Checks"}
                       <div class="check-select-wrapper">
@@ -855,6 +908,99 @@
 
   .toggle-hint.warning {
     color: var(--vscode-editorWarning-foreground);
+  }
+
+  /* Containers Section (inside Tools group) */
+  .containers-section {
+    border-top: 1px solid var(--vscode-panel-border);
+    display: flex;
+    flex-direction: column;
+  }
+
+  .containers-toggle {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    padding: 3px 8px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--vscode-descriptionForeground);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    opacity: 0.7;
+    text-align: left;
+  }
+
+  .containers-toggle:hover {
+    color: var(--vscode-foreground);
+    opacity: 1;
+  }
+
+  .containers-rows {
+    display: flex;
+    flex-direction: column;
+    padding: 2px 8px 4px 8px;
+    gap: 2px;
+  }
+
+  .container-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 1px 0;
+  }
+
+  .ct-model {
+    font-size: 11px;
+    font-family: var(--vscode-editor-font-family, monospace);
+    color: var(--vscode-foreground);
+    width: 52px;
+    flex-shrink: 0;
+  }
+
+  .ct-dot {
+    font-size: 10px;
+    flex-shrink: 0;
+  }
+
+  .ct-dot--running { color: #4caf50; }
+  .ct-dot--stopped { color: #ff9800; }
+  .ct-dot--missing { color: var(--vscode-disabledForeground, #666); }
+
+  .ct-btn {
+    font-size: 10px;
+    font-family: var(--vscode-font-family);
+    padding: 2px 7px;
+    border: none;
+    border-radius: 2px;
+    cursor: pointer;
+    letter-spacing: 0.04em;
+    font-weight: 600;
+  }
+
+  .ct-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+
+  .ct-btn--primary {
+    background-color: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+  }
+
+  .ct-btn--primary:hover:not(:disabled) {
+    background-color: var(--vscode-button-hoverBackground);
+  }
+
+  .ct-btn--secondary {
+    background-color: var(--vscode-button-secondaryBackground);
+    color: var(--vscode-button-secondaryForeground);
+  }
+
+  .ct-btn--secondary:hover:not(:disabled) {
+    background-color: var(--vscode-button-secondaryHoverBackground);
   }
 
   /* Actions Toggle */

--- a/src/webview/components/ActionGroup.svelte
+++ b/src/webview/components/ActionGroup.svelte
@@ -38,6 +38,7 @@
     onTogglePin: (actionId: string) => void;
     onToggleExpand?: () => void;
     optionSuffix?: Snippet<[Action]>; // content to render inline after an option
+    headerSuffix?: Snippet; // content rendered below main action, always visible
     children?: Snippet;
   }
 
@@ -49,6 +50,7 @@
     onTogglePin,
     onToggleExpand,
     optionSuffix,
+    headerSuffix,
     children,
   }: Props = $props();
 
@@ -134,6 +136,10 @@
       </span>
     </button>
   </div>
+
+  {#if headerSuffix}
+    {@render headerSuffix()}
+  {/if}
 
   {#if group.expanded && !disabled}
     <div class="options-panel">

--- a/src/webview/components/TestsList.svelte
+++ b/src/webview/components/TestsList.svelte
@@ -23,6 +23,7 @@
     isRefreshing: boolean;
     refreshTests: () => void;
     sendSelectedTests: (testCases: TestCase[]) => void;
+    selectFailedTests: () => void;
   }
 
   let {
@@ -31,6 +32,7 @@
     isRefreshing,
     refreshTests,
     sendSelectedTests,
+    selectFailedTests,
   }: Props = $props();
 
   let searchQuery = $state("");
@@ -154,6 +156,15 @@
           title="Filter tests"
         >
           <i class="codicon codicon-search"></i>
+        </button>
+      {/if}
+      {#if !isRefreshing && testCases.length > 0}
+        <button
+          class="icon-button"
+          onclick={selectFailedTests}
+          title="Select failed tests from last run"
+        >
+          <i class="codicon codicon-error"></i>
         </button>
       {/if}
       <button class="icon-button" onclick={refreshTests} title="Refresh test list">

--- a/src/webview/webviewProvider.ts
+++ b/src/webview/webviewProvider.ts
@@ -1,6 +1,8 @@
 import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
 import { TaskSpec } from "../taskProvider";
-import { setSelectedTests, setVerboseTests } from "../appSelector";
+import { setSelectedTests, setVerboseTests, getSelectedApp } from "../appSelector";
 import { LedgerDevice, SpecialAllDevice } from "../targetSelector";
 import { DevImageStatus } from "../types";
 import { setSelectedModel } from "../aiReviewer";
@@ -10,6 +12,13 @@ import { setSelectedModel } from "../aiReviewer";
  * - null: clear the content for this section
  * - object: update with provided data
  */
+export type ContainerTargetStatus = "running" | "stopped" | "missing";
+export interface ContainerTargetInfo {
+  model: string;
+  containerName: string;
+  status: ContainerTargetStatus;
+}
+
 export interface WebviewRefreshOptions {
   apps?: {
     list: string[];
@@ -35,6 +44,7 @@ export interface WebviewRefreshOptions {
     selected: string;
   } | null;
   containerStatus?: DevImageStatus | null;
+  containerStatuses?: ContainerTargetInfo[] | null;
   dockerRunning?: boolean;
   imageOutdated?: boolean;
   enforcerChecks?: {
@@ -163,6 +173,13 @@ export class Webview implements vscode.WebviewViewProvider {
       });
     }
 
+    if (options.containerStatuses !== undefined) {
+      this._view.webview.postMessage({
+        command: "containerStatuses",
+        statuses: options.containerStatuses ?? [],
+      });
+    }
+
     // Send containerStatus last — the webview uses it as a "ready" signal
     if (options.containerStatus !== undefined) {
       this._view.webview.postMessage({
@@ -274,12 +291,70 @@ export class Webview implements vscode.WebviewViewProvider {
           const args: any[] = data.args || [];
           console.log("Executing command from webview : ", command, args);
           await vscode.commands.executeCommand(command, ...args);
+          break;
         }
         case "updateSelectedTests":
           {
             const selectedTests: string[] = data.selectedTests;
             console.log("Updating selected tests from webview : ", selectedTests);
             setSelectedTests(selectedTests);
+          }
+          break;
+        case "selectFailedTests":
+          {
+            const app = getSelectedApp();
+            if (!app || !app.functionalTestsList || app.functionalTestsList.length === 0) {
+              vscode.window.showWarningMessage("No tests loaded. Please refresh the test list first.");
+              break;
+            }
+
+            const cachePaths = [
+              path.join(app.folderUri.fsPath, ".pytest_cache", "v", "cache", "lastfailed"),
+              ...(app.functionalTestsDir
+                ? [path.join(app.folderUri.fsPath, app.functionalTestsDir, ".pytest_cache", "v", "cache", "lastfailed")]
+                : []),
+            ];
+
+            let failedIds: string[] = [];
+            for (const cachePath of cachePaths) {
+              if (fs.existsSync(cachePath)) {
+                try {
+                  const raw = JSON.parse(fs.readFileSync(cachePath, "utf-8")) as Record<string, boolean>;
+                  failedIds = [...new Set(
+                    Object.keys(raw).map(id => {
+                      const parts = id.split("::");
+                      const testName = parts[parts.length - 1].split("[")[0];
+                      const filePart = parts.slice(0, parts.length - 1).join("::");
+                      return filePart ? `${filePart}::${testName}` : testName;
+                    }),
+                  )];
+                }
+                catch {
+                  vscode.window.showErrorMessage("Failed to read pytest cache file.");
+                }
+                break;
+              }
+            }
+
+            if (failedIds.length === 0) {
+              vscode.window.showInformationMessage("No failed tests found in pytest cache.");
+              break;
+            }
+
+            const matched = failedIds.filter(id => app.functionalTestsList!.includes(id));
+
+            if (matched.length === 0) {
+              vscode.window.showWarningMessage("Failed tests from cache don't match the current test list. Try refreshing the test list.");
+              break;
+            }
+
+            setSelectedTests(matched);
+            await this.refresh({
+              testCases: {
+                list: app.functionalTestsList,
+                selected: matched,
+              },
+            });
           }
           break;
         case "appSelected":

--- a/src/webview/webviewProvider.ts
+++ b/src/webview/webviewProvider.ts
@@ -323,7 +323,7 @@ export class Webview implements vscode.WebviewViewProvider {
                   // Strip parametrize suffixes (e.g. test_foo[param]) so all
                   // variants of a test are selected when any variant failed.
                   failedIds = [...new Set(
-                    Object.keys(raw).map(id => {
+                    Object.keys(raw).map((id) => {
                       const parts = id.split("::");
                       const testName = parts[parts.length - 1].split("[")[0];
                       const filePart = parts.slice(0, parts.length - 1).join("::");

--- a/src/webview/webviewProvider.ts
+++ b/src/webview/webviewProvider.ts
@@ -320,6 +320,8 @@ export class Webview implements vscode.WebviewViewProvider {
               if (fs.existsSync(cachePath)) {
                 try {
                   const raw = JSON.parse(fs.readFileSync(cachePath, "utf-8")) as Record<string, boolean>;
+                  // Strip parametrize suffixes (e.g. test_foo[param]) so all
+                  // variants of a test are selected when any variant failed.
                   failedIds = [...new Set(
                     Object.keys(raw).map(id => {
                       const parts = id.split("::");


### PR DESCRIPTION
Adds per-target container management so each Speculos device model (flex, stax, nanos+, …) runs in its own Docker container (`<app>-<model>`). Includes a new Containers panel in the webview with per-container status indicators and stop/clean/recreate actions, a "select failed tests" button backed by pytest's `lastfailed` cache, and a shared pip cache volume for faster installs. Container/Update tasks run sequentially when "All" is selected to avoid concurrent `docker pull` races.

**Breaking**: the task type identifier changes from `"L"` to `"ledger"` — any custom `tasks.json` entries must be updated.